### PR TITLE
1 updated eof handling

### DIFF
--- a/cmpfile.go
+++ b/cmpfile.go
@@ -39,12 +39,12 @@ func areFileContentsEqual(s status, pathname1, pathname2 string) (bool, error) {
 	}
 	defer f2.Close()
 
-	eq, err := readerContentsEqual(s, f1, f2)
+	eq, err := fileContentsEqual(s, f1, f2)
 	return eq, err
 }
 
 // Return true if r1 and r2 have identical contents. Otherwise return false.
-func readerContentsEqual(s status, r1, r2 io.Reader) (bool, error) {
+func fileContentsEqual(s status, r1, r2 *os.File) (bool, error) {
 	var atEnd bool
 	bufSize := minCmpBufSize
 

--- a/fsdev.go
+++ b/fsdev.go
@@ -141,8 +141,8 @@ func (f *fsDev) FindIdenticalFiles(di I.DevStatInfo, pathname string) (err error
 func (f *fsDev) cachedInos(H I.Hash, ps I.PathInfo) ([]I.Ino, bool) {
 	var cachedSeq []I.Ino
 	cachedSet := f.inoHashes[H]
-	// If digests are enabled, and cached inode lists are
-	// long enough, then switch on the use of digests.
+	// If digest option is enabled, and cached inode lists are long enough,
+	// then use digests in the search.
 	thresh := f.Options.SearchThresh
 	useDigest := thresh >= 0 && len(cachedSet) > thresh
 	if useDigest {
@@ -158,6 +158,9 @@ func (f *fsDev) cachedInos(H I.Hash, ps I.PathInfo) ([]I.Ino, bool) {
 			noDigests := cachedSet.Difference(f.InosWithDigest)
 			sameDigests := cachedSet.Intersection(f.InoDigests.GetInos(digest))
 			cachedSeq = append(sameDigests.AsSlice(), noDigests.AsSlice()...)
+		} else {
+			// Resort to the non-digest search upon error
+			cachedSeq = cachedSet.AsSlice()
 		}
 	} else {
 		cachedSeq = cachedSet.AsSlice()

--- a/fsdev.go
+++ b/fsdev.go
@@ -201,6 +201,8 @@ func (f *fsDev) areFilesLinkable(pi1 I.PathInfo, pi2 I.PathInfo, useDigest bool)
 		}
 	}
 
+	// Compute digest for both files, since they will have to be read in
+	// anyway for comparison.
 	if useDigest {
 		if f.InoDigests.NewDigest(pi1, f.digestBuf) {
 			f.Results.computedDigest()

--- a/internal/inode/digest.go
+++ b/internal/inode/digest.go
@@ -86,7 +86,7 @@ func ContentDigest(pathname string, buf []byte) (Digest, error) {
 	}
 	defer f.Close()
 
-	n, err := f.Read(buf)
+	n, err := ReadChunk(f, buf)
 	if err != nil && err != io.EOF {
 		return 0, err
 	}

--- a/internal/inode/digest.go
+++ b/internal/inode/digest.go
@@ -22,6 +22,7 @@ package inode
 
 import (
 	"hash/fnv"
+	"io"
 	"os"
 )
 
@@ -86,7 +87,7 @@ func ContentDigest(pathname string, buf []byte) (Digest, error) {
 	defer f.Close()
 
 	n, err := f.Read(buf)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return 0, err
 	}
 	if n < len(buf) {

--- a/internal/inode/readchunk.go
+++ b/internal/inode/readchunk.go
@@ -1,0 +1,38 @@
+package inode
+
+import (
+	"fmt"
+	"os"
+)
+
+// ReadChunk will retry Read() until it fills the buf, or reaches EOF or
+// an error.
+func ReadChunk(f *os.File, buf []byte) (n int, err error) {
+	// For Posix reads of normal files, Read() will almost certainly return
+	// a maximal Read() (or non-EOF error), but just in case, we make sure
+	// to attempt to return a maximal chunk anyway.  Simple spin protection
+	// in case of (0,nil) Read() returns, which again shouldn't happen.
+	// Basically, this is pure overkill. :)
+	const spinLimit = 10
+	spinCount := 0
+	N := len(buf)
+	for {
+		var nn int
+		nn, err = f.Read(buf)
+		n += nn
+		if n == N || err != nil {
+			break
+		}
+
+		if nn == 0 {
+			spinCount++
+		} else {
+			spinCount = 0
+			buf = buf[nn:] // crawl forward
+		}
+		if spinCount > spinLimit {
+			return n, fmt.Errorf("stuck read for file: %v", f.Name())
+		}
+	}
+	return
+}

--- a/state.go
+++ b/state.go
@@ -25,9 +25,9 @@ import (
 	P "github.com/chadnetzer/hardlinkable/internal/pathpool"
 )
 
-const minCmpBufSize = 4 * 1024
-const maxCmpBufSize = 32 * 1024
-const digestBufSize = 4 * 1024
+const maxCmpBufSize = 8 * minCmpBufSize // Power of two multiplier
+const minCmpBufSize = 4096
+const digestBufSize = 4096
 
 type status struct {
 	Options   *Options


### PR DESCRIPTION
Better handling of EOF for non-zero bytes returned file.Read() in cmpfile and digest.

Addresses GH issue #1 